### PR TITLE
Fix: List with euca instances

### DIFF
--- a/openstack/compute/servers.py
+++ b/openstack/compute/servers.py
@@ -95,7 +95,10 @@ class Server(base.Resource):
         """
         Shortcut to get this server's primary public IP address.
         """
-        return self.addresses['public'][0]
+        if self.addresses['public']:
+            return self.addresses['public'][0]
+        else:
+            return u''
     
     @property
     def private_ip(self):


### PR DESCRIPTION
This is an interoperability patch to allow euca instances to be listed without an index out of range exception being thrown.
