### PR TITLE
check if private ip is empty before indexing it

### DIFF
--- a/openstack/compute/servers.py
+++ b/openstack/compute/servers.py
@@ -105,7 +105,10 @@ class Server(base.Resource):
         """
         Shortcut to get this server's primary private IP address.
         """
-        return self.addresses['private'][0]
+        if self.addresses['private']:
+            return self.addresses['private'][0]
+        else:
+            return u''
     
 class ServerManager(base.ManagerWithFind):
     resource_class = Server


### PR DESCRIPTION
If an instance does not have it's private ip set at the time that it's listed, openstack.compute throws an exception as follows:

> > > l = cp.servers.list()
> > > l[0].private_ip
> > > Traceback (most recent call last):
> > >   File "<console>", line 1, in <module>
> > >   File ".../openstack.compute/openstack/compute/servers.py", line 115, in private_ip
> > >     return self.addresses['private'][0]
> > > IndexError: list index out of range

This patch checks for the private ip's existence first so that the exception isn't thrown.
