### PR TITLE
Updating docs to mention corrent ENV var for api key.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ with the ``--username`` and ``--apikey`` params, but it's easier to just set
 them as environment variables::
 
     export OPENSTACK_COMPUTE_USERNAME=jacobian
-    export OPENSTACK_COMPUTE_API_KEY=yadayada
+    export OPENSTACK_COMPUTE_APIKEY=yadayada
 
 You'll find complete documentation on the shell by running
 ``cloudservers help``::
@@ -79,7 +79,7 @@ You'll find complete documentation on the shell by running
 
     Optional arguments:
       --username USERNAME   Defaults to env[OPENSTACK_COMPUTE_USERNAME].
-      --apikey APIKEY       Defaults to env[OPENSTACK_COMPUTE_API_KEY].
+      --apikey APIKEY       Defaults to env[OPENSTACK_COMPUTE_APIKEY].
 
     See "openstack-compute help COMMAND" for help on a specific command.
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -17,7 +17,7 @@ Release notes
       ``cloudservers``. Yes, the name's a lot longer. Use ``alias``.
       
     * The env variables are now ``OPENSTACK_COMPUTE_USERNAME`` and
-      ``OPENSTACK_COMPUTE_API_KEY``.
+      ``OPENSTACK_COMPUTE_APIKEY``.
 
 1.2 (August 15, 2010)
 =====================

--- a/docs/shell.rst
+++ b/docs/shell.rst
@@ -27,14 +27,14 @@ variables by setting two environment variables:
 
     Your Rackspace Cloud username.
 
-.. envvar:: OPENSTACK_COMPUTE_API_KEY
+.. envvar:: OPENSTACK_COMPUTE_APIKEY
 
     Your API key.
 
 For example, in Bash you'd use::
 
     export COPENSTACK_COMPUTE_USERNAME=yourname
-    export COPENSTACK_COMPUTE_API_KEY=yadayadayada
+    export COPENSTACK_COMPUTE_APIKEY=yadayadayada
     
 From there, all shell commands take the form::
     


### PR DESCRIPTION
That about says it.  I changed the docs, not the code, but you could use the spelling from the code version instead.  Thanks
