### PR TITLE
The use of authorized_keys2 for protocol 2 has been deprecated and is no longer supported by some distros

### DIFF
--- a/openstack/compute/shell.py
+++ b/openstack/compute/shell.py
@@ -262,7 +262,7 @@ class ComputeShell(object):
 
         if keyfile:
             try:
-                files['/root/.ssh/authorized_keys2'] = open(keyfile)
+                files['/root/.ssh/authorized_keys'] = open(keyfile)
             except IOError, e:
                 raise CommandError("Can't open '%s': %s" % (keyfile, e))
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-requirements = ['httplib2', 'argparse', 'prettytable']
+requirements = ['httplib2==0.7.4', 'argparse==1.2.1', 'prettytable==0.5']
 if sys.version_info < (2,6):
     requirements.append('simplejson')
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -104,7 +104,7 @@ def test_boot_key_auto():
             'POST', '/servers',
             {'server': {'flavorId': 1, 'name': 'some-server', 'imageId': 1,
                         'personality': [{
-                            'path': '/root/.ssh/authorized_keys2',
+                            'path': '/root/.ssh/authorized_keys',
                             'contents': ('SSHKEY').encode('base64')},
                         ]}
             }
@@ -129,7 +129,7 @@ def test_boot_key_file():
         'POST', '/servers',
         {'server': {'flavorId': 1, 'name': 'some-server', 'imageId': 1,
                     'personality': [
-                        {'path': '/root/.ssh/authorized_keys2', 'contents': expected_file_data},
+                        {'path': '/root/.ssh/authorized_keys', 'contents': expected_file_data},
                     ]}
         }
     )


### PR DESCRIPTION
Rackspace recently upgraded Arch Linux to a newer image which no longer supports the deprecated, since 2001, authorized_keys2. openstack.compute was uploading my public key to ~/.ssh/authorized_keys2 instead of ~/.ssh/authorized_keys. I discovered this because I began receiving a password prompt each and every login and took a look at Arch's default /etc/ssh/sshd_config.

See the discussion here:
http://serverfault.com/questions/116177/whats-the-difference-between-authorized-keys-and-authorized-keys2
